### PR TITLE
Possible improvement for settings as described in issue #1032

### DIFF
--- a/.abapgit.xml
+++ b/.abapgit.xml
@@ -13,6 +13,7 @@
     <item>/package.json</item>
     <item>/changelog.txt</item>
     <item>/.gitignore</item>
+    <item>/CODE_OF_CONDUCT.md</item>
    </IGNORE>
   </DATA>
  </asx:values>

--- a/src/zabapgit_http.prog.abap
+++ b/src/zabapgit_http.prog.abap
@@ -216,7 +216,7 @@ CLASS lcl_http_client IMPLEMENTATION.
           code    = lv_code
           message = lv_message ).
 
-      lv_text = |HTTP error { lv_code } occured: { lv_code }|.
+      lv_text = |HTTP error { lv_code } occured: { lv_message }|.
 
 *      CASE sy-subrc.
 *        WHEN 1.

--- a/src/zabapgit_http.prog.abap
+++ b/src/zabapgit_http.prog.abap
@@ -209,7 +209,13 @@ CLASS lcl_http_client IMPLEMENTATION.
         http_invalid_state         = 2
         http_processing_failed     = 3
         OTHERS                     = 4 ).
+
     IF sy-subrc <> 0.
+      " in case of HTTP_COMMUNICATION_FAILURE
+      " make sure:
+      " a) SSL is setup properly in STRUST
+      " b) no firewalls
+      " check trace file in transaction SMICM
 
       mi_client->get_last_error(
         IMPORTING
@@ -217,21 +223,6 @@ CLASS lcl_http_client IMPLEMENTATION.
           message = lv_message ).
 
       lv_text = |HTTP error { lv_code } occured: { lv_message }|.
-
-*      CASE sy-subrc.
-*        WHEN 1.
-*          " make sure:
-*          " a) SSL is setup properly in STRUST
-*          " b) no firewalls
-*          " check trace file in transaction SMICM
-*          lv_text = 'HTTP Communication Failure'.           "#EC NOTEXT
-*        WHEN 2.
-*          lv_text = 'HTTP Invalid State'.                   "#EC NOTEXT
-*        WHEN 3.
-*          lv_text = 'HTTP Processing failed'.               "#EC NOTEXT
-*        WHEN OTHERS.
-*          lv_text = 'Another error occured'.                "#EC NOTEXT
-*      ENDCASE.
 
       zcx_abapgit_exception=>raise( lv_text ).
     ENDIF.

--- a/src/zabapgit_http.prog.abap
+++ b/src/zabapgit_http.prog.abap
@@ -198,7 +198,9 @@ CLASS lcl_http_client IMPLEMENTATION.
 
   METHOD send_receive.
 
-    DATA lv_text TYPE string.
+    DATA: lv_text    TYPE string,
+          lv_code    TYPE i,
+          lv_message TYPE string.
 
     mi_client->send( ).
     mi_client->receive(
@@ -208,20 +210,29 @@ CLASS lcl_http_client IMPLEMENTATION.
         http_processing_failed     = 3
         OTHERS                     = 4 ).
     IF sy-subrc <> 0.
-      CASE sy-subrc.
-        WHEN 1.
-          " make sure:
-          " a) SSL is setup properly in STRUST
-          " b) no firewalls
-          " check trace file in transaction SMICM
-          lv_text = 'HTTP Communication Failure'.           "#EC NOTEXT
-        WHEN 2.
-          lv_text = 'HTTP Invalid State'.                   "#EC NOTEXT
-        WHEN 3.
-          lv_text = 'HTTP Processing failed'.               "#EC NOTEXT
-        WHEN OTHERS.
-          lv_text = 'Another error occured'.                "#EC NOTEXT
-      ENDCASE.
+
+      mi_client->get_last_error(
+        IMPORTING
+          code    = lv_code
+          message = lv_message ).
+
+      lv_text = |HTTP error { lv_code } occured: { lv_code }|.
+
+*      CASE sy-subrc.
+*        WHEN 1.
+*          " make sure:
+*          " a) SSL is setup properly in STRUST
+*          " b) no firewalls
+*          " check trace file in transaction SMICM
+*          lv_text = 'HTTP Communication Failure'.           "#EC NOTEXT
+*        WHEN 2.
+*          lv_text = 'HTTP Invalid State'.                   "#EC NOTEXT
+*        WHEN 3.
+*          lv_text = 'HTTP Processing failed'.               "#EC NOTEXT
+*        WHEN OTHERS.
+*          lv_text = 'Another error occured'.                "#EC NOTEXT
+*      ENDCASE.
+
       zcx_abapgit_exception=>raise( lv_text ).
     ENDIF.
 
@@ -502,7 +513,7 @@ CLASS lcl_http IMPLEMENTATION.
 
     DATA: lv_host TYPE string,
           lt_list TYPE zif_abapgit_definitions=>ty_icm_sinfo2_tt,
-          li_exit TYPE ref to lif_exit.
+          li_exit TYPE REF TO lif_exit.
 
     CALL FUNCTION 'ICM_GET_INFO2'
       TABLES

--- a/src/zabapgit_object_iamu.prog.abap
+++ b/src/zabapgit_object_iamu.prog.abap
@@ -116,8 +116,7 @@ CLASS lcl_object_iamu IMPLEMENTATION.
         object_not_existing          = 9
         object_invalid               = 10
         error_occured                = 11
-        content_data_error           = 12
-        OTHERS                       = 13 ).
+        OTHERS                       = 12 ).
 
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise( |Error from if_w3_api_mime~set_changeable| ).
@@ -303,8 +302,7 @@ CLASS lcl_object_iamu IMPLEMENTATION.
         object_not_existing          = 9
         object_invalid               = 10
         error_occured                = 11
-        content_data_error           = 12
-        OTHERS                       = 13 ).
+        OTHERS                       = 12 ).
 
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise( |Error from if_w3_api_mime~set_changeable| ).

--- a/src/zabapgit_object_webi.prog.abap
+++ b/src/zabapgit_object_webi.prog.abap
@@ -179,6 +179,11 @@ CLASS lcl_object_webi IMPLEMENTATION.
 
   METHOD handle_function.
 
+    CONSTANTS: BEGIN OF co_parameter_type,
+                 import TYPE vepparamtype VALUE 'I',
+                 export TYPE vepparamtype VALUE 'O',
+               END OF co_parameter_type.
+
     DATA: li_parameter TYPE REF TO if_ws_md_vif_param,
           li_soap      TYPE REF TO if_ws_md_soap_ext_func,
           li_fault     TYPE REF TO if_ws_md_vif_fault,
@@ -205,16 +210,22 @@ CLASS lcl_object_webi IMPLEMENTATION.
 
       LOOP AT is_webi-pvepparameter ASSIGNING <ls_parameter>
           WHERE function = <ls_function>-function.
+
         CASE <ls_parameter>-vepparamtype.
-          WHEN 'I'.
+          WHEN co_parameter_type-import.
+
             li_parameter = li_function->create_incoming_parameter(
               <ls_parameter>-vepparam ).
-          WHEN 'E'.
+
+          WHEN co_parameter_type-export.
+
             li_parameter = li_function->create_outgoing_parameter(
               <ls_parameter>-vepparam ).
+
           WHEN OTHERS.
             ASSERT 0 = 1.
         ENDCASE.
+
         li_parameter->set_name_mapped_to( <ls_parameter>-mappedname ).
         li_parameter->set_is_exposed( <ls_parameter>-is_exposed ).
         li_parameter->set_is_optional( <ls_parameter>-is_optional ).


### PR DESCRIPTION
As described in issue #1032, settings are currently read quite often when working with the object types (e.g. to determine if experimental features are active) and each access currently triggers a read on the database.
I have added a simple buffering for the settings, which reads the settings only once from the database per session and instance and then keeps the buffrered data up to date when changes are commited.

There are currently two unsolved issues for which I need feedback before I can address them:

1. Since there can be multiple instances of the `lcl_persist_settings` class, in theory they can diverge in their state if modify is only called for one instance. At first glance this does not seem to be a big problem, because most accesses go though the singleton instance in `lcl_app=>setting( )`. But I'm not sure if really all settings accesses go through `lcl_app`.
2. I have not yet figured out how the unit test classes work, so I can't tell if buffering in the `lcl_persist_settings` class is compatible with the any automated test available for abapGit. 

If you can provide feedback for these two issues, I can address them prior to a possible merge.